### PR TITLE
Add a method to check for user activity more efficiently

### DIFF
--- a/README
+++ b/README
@@ -331,6 +331,11 @@ Interface "shutdown"
   The boolean argument "ignoreuser" will ignore user activity. This may be
   useful for external frontends like XBMC etc..
 
+- ask if user is active
+  vdr-dbus-send.sh /Shutdown shutdown.UserActive
+  This is a more efficient way to check if the user is active than using ConfirmShutdown,
+  because the shutdown hooks won't be executed if the user is inactive.
+
 - ask if vdr was started manually
   vdr-dbus-send.sh /Shutdown shutdown.ManualStart
   Actually it compares the startup time of vdr with the current set NextWakeupTime.

--- a/README
+++ b/README
@@ -332,7 +332,7 @@ Interface "shutdown"
   useful for external frontends like XBMC etc..
 
 - ask if user is active
-  vdr-dbus-send.sh /Shutdown shutdown.UserActive
+  vdr-dbus-send.sh /Shutdown shutdown.IsUserActive
   This is a more efficient way to check if the user is active than using ConfirmShutdown,
   because the shutdown hooks won't be executed if the user is inactive.
 

--- a/shutdown.c
+++ b/shutdown.c
@@ -26,7 +26,7 @@ public:
     g_variant_builder_unref(builder);
   };
 
-  static void UserActive(cDBusObject *Object, GVariant *Parameters, GDBusMethodInvocation *Invocation)
+  static void IsUserActive(cDBusObject *Object, GVariant *Parameters, GDBusMethodInvocation *Invocation)
   {
     gboolean active = !ShutdownHandler.IsUserInactive();
     g_dbus_method_invocation_return_value(Invocation, g_variant_new("(b)", active));
@@ -239,7 +239,7 @@ const char *cDBusShutdownHelper::_xmlNodeInfo =
     "       \"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
     "<node>\n"
     "  <interface name=\""DBUS_VDR_SHUTDOWN_INTERFACE"\">\n"
-    "    <method name=\"UserActive\">\n"
+    "    <method name=\"IsUserActive\">\n"
     "      <arg name=\"active\"       type=\"b\" direction=\"out\"/>\n"
     "    </method>\n"
     "    <method name=\"ConfirmShutdown\">\n"
@@ -281,7 +281,7 @@ void cDBusShutdown::SetShutdownHooksWrapper(const char *Wrapper)
 cDBusShutdown::cDBusShutdown(void)
 :cDBusObject("/Shutdown", cDBusShutdownHelper::_xmlNodeInfo)
 {
-  AddMethod("UserActive", cDBusShutdownHelper::UserActive);
+  AddMethod("IsUserActive", cDBusShutdownHelper::IsUserActive);
   AddMethod("ConfirmShutdown" , cDBusShutdownHelper::ConfirmShutdown);
   AddMethod("ManualStart" , cDBusShutdownHelper::ManualStart);
   AddMethod("NextWakeupTime" , cDBusShutdownHelper::NextWakeupTime);

--- a/shutdown.c
+++ b/shutdown.c
@@ -26,6 +26,12 @@ public:
     g_variant_builder_unref(builder);
   };
 
+  static void UserActive(cDBusObject *Object, GVariant *Parameters, GDBusMethodInvocation *Invocation)
+  {
+    gboolean active = !ShutdownHandler.IsUserInactive();
+    g_dbus_method_invocation_return_value(Invocation, g_variant_new("(b)", active));
+  }
+
   static void ConfirmShutdown(cDBusObject *Object, GVariant *Parameters, GDBusMethodInvocation *Invocation)
   {
     gboolean ignoreuser = FALSE;
@@ -233,6 +239,9 @@ const char *cDBusShutdownHelper::_xmlNodeInfo =
     "       \"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd\">\n"
     "<node>\n"
     "  <interface name=\""DBUS_VDR_SHUTDOWN_INTERFACE"\">\n"
+    "    <method name=\"UserActive\">\n"
+    "      <arg name=\"active\"       type=\"b\" direction=\"out\"/>\n"
+    "    </method>\n"
     "    <method name=\"ConfirmShutdown\">\n"
     "      <arg name=\"ignoreuser\"   type=\"b\" direction=\"in\"/>\n"
     "      <arg name=\"replycode\"    type=\"i\" direction=\"out\"/>\n"
@@ -272,6 +281,7 @@ void cDBusShutdown::SetShutdownHooksWrapper(const char *Wrapper)
 cDBusShutdown::cDBusShutdown(void)
 :cDBusObject("/Shutdown", cDBusShutdownHelper::_xmlNodeInfo)
 {
+  AddMethod("UserActive", cDBusShutdownHelper::UserActive);
   AddMethod("ConfirmShutdown" , cDBusShutdownHelper::ConfirmShutdown);
   AddMethod("ManualStart" , cDBusShutdownHelper::ManualStart);
   AddMethod("NextWakeupTime" , cDBusShutdownHelper::NextWakeupTime);


### PR DESCRIPTION
than ConfirmShutdown, so the shutdown wrapper won't be called unnecessarily if the user is inactive.