### PR TITLE
vdr-dbus-send.sh: add support for VDR instance id (#2)

### DIFF
--- a/README
+++ b/README
@@ -50,8 +50,8 @@ Multi Instance Support
 The default destination address is "de.tvdr.vdr". In case of a vdr version above 1.7.4 and an
 instance id (vdr parameter -i) greater than 0, this instance id is appended to this address,
 e.g. "de.tvdr.vdr1". If you use this feature you have to clone the dbus-policy file and change
-the address. Also vdr-dbus-send.sh is not ready for this - use dbus-send or whatever you use to
-communicate with dbus2vdr...
+the address. For vdr-dbus-send.sh set the environment variable VDR_ID to the instance id - e.g.:
+VDR_ID=1 vdr-dbus-send.sh /Status status.IsReplaying
 
 Commandline Arguments
 ---------------------

--- a/bin/vdr-dbus-send.sh
+++ b/bin/vdr-dbus-send.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+declare -i VDR_ID=${VDR_ID:-0}
+
 if [ $# -lt 2 ]
 then
   echo "usage: $0 objectpath interface.method [arguments]"
@@ -7,9 +9,11 @@ then
 fi
 
 DEST=de.tvdr.vdr
+INTERFACE_DEST="$DEST"
+(( VDR_ID > 0 )) && DEST+="${VDR_ID}"
 OBJECT=$1
 shift
 INTERFACE=$1
 shift
 
-dbus-send --system --type=method_call --dest=$DEST --print-reply $OBJECT $DEST.$INTERFACE "$@"
+dbus-send --system --type=method_call --dest=$DEST --print-reply $OBJECT $INTERFACE_DEST.$INTERFACE "$@"


### PR DESCRIPTION
* vdr-dbus-send.sh: add support for VDR instance id

Use the VDR_ID environment variable if set (otherwise default to ID 0) and change the destination accordingly,
so it is possible to choose a vdr instance by setting VDR_ID as an environment variable, e.g.
```shell
VDR_ID=1 vdr-dbus-send /Plugins Plugin.List
```

* Update README